### PR TITLE
Fix: Sync dashboard with localStorage transactions

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,26 @@ export default function DashboardPage() {
     setMounted(true);
     // Here you would typically fetch transactions and categories
     // For now, we use initial data.
-  }, []);
+    if (mounted) {
+      try {
+        const storedTransactions = localStorage.getItem('transactions');
+        if (storedTransactions) {
+          const parsedTransactions = JSON.parse(storedTransactions);
+          if (Array.isArray(parsedTransactions)) {
+            // Basic type validation for each transaction can be added here if necessary
+            setTransactions(parsedTransactions);
+          } else {
+            console.error('Stored transactions are not an array, using initial transactions.');
+            // transactions state already defaults to initialTransactions
+          }
+        }
+        // If storedTransactions is null, transactions state already defaults to initialTransactions
+      } catch (error) {
+        console.error('Failed to parse transactions from localStorage, using initial transactions:', error);
+        // transactions state already defaults to initialTransactions
+      }
+    }
+  }, [mounted]); // Add mounted to dependency array
 
   const summary = useMemo(() => {
     const totalIncome = transactions


### PR DESCRIPTION
I modified the DashboardPage (`src/app/page.tsx`) to load transaction data from localStorage.

This ensures that your dashboard reflects the latest transactions you added or modified via the TransactionsPage, addressing the issue where the dashboard would only show initial hardcoded data.

Key changes:
- In `src/app/page.tsx`:
  - The `useEffect` hook now attempts to load 'transactions' from localStorage when the component mounts.
  - If data is found and is valid, it updates the dashboard's transaction state.
  - If no data is found or it's invalid, the dashboard falls back to its default initial transactions.
  - localStorage access is conditional on the component being mounted to ensure client-side execution.