### PR TITLE
Fix: Initialize 'watch' before use in CategoryManager

### DIFF
--- a/src/components/budgets/category-manager.tsx
+++ b/src/components/budgets/category-manager.tsx
@@ -60,9 +60,9 @@ export function CategoryManager({ onSave, onCancel, initialData }: CategoryManag
     reset();
   };
   
+  const { watch } = useForm(); // To watch icon changes
   // Dynamically get icon component for preview
   const SelectedIcon = (LucideIcons as any)[watch('icon') || 'Shapes'] || LucideIcons.Shapes;
-  const { watch } = useForm(); // To watch icon changes
 
   return (
     <form onSubmit={handleSubmit(processSubmit)} className="space-y-4 py-4">


### PR DESCRIPTION
Resolves an error where 'watch' from react-hook-form was accessed before initialization when selecting an icon in the budget category manager. Moved the `useForm()` hook call to ensure `watch` is defined before it's used to determine the SelectedIcon.